### PR TITLE
feat(pipeline): pipeline orchestrator, API routes, SSE streaming, demo mode

### DIFF
--- a/app/routers/health.py
+++ b/app/routers/health.py
@@ -1,0 +1,10 @@
+"""Health check endpoint."""
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/api/v1/health")
+async def health():
+    return {"status": "healthy", "version": "0.1.0"}

--- a/app/routers/pipeline.py
+++ b/app/routers/pipeline.py
@@ -1,0 +1,143 @@
+"""Pipeline API routes — run pipeline, stream SSE events, demo mode."""
+
+import json
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
+from sse_starlette.sse import EventSourceResponse
+
+from app.config import settings
+from app.file_parser import parse_file
+from app.schemas import PipelineRunResponse, PipelineStatus
+
+logger = logging.getLogger("agencyflow.router.pipeline")
+
+router = APIRouter(prefix="/api/v1/pipeline", tags=["pipeline"])
+
+# Pre-computed demo outputs directory
+DEMO_DATA_DIR = Path(__file__).parent.parent.parent / "data" / "precomputed"
+
+
+@router.post("/run", status_code=202)
+async def run_pipeline(
+    request: Request,
+    file: UploadFile | None = File(None),
+    text: str | None = Form(None),
+) -> PipelineRunResponse:
+    """Start a new pipeline run.
+
+    Accepts either a file upload (PDF/TXT) or raw text. File takes precedence.
+    Returns 202 Accepted with a run_id for SSE streaming.
+
+    WHY 202 instead of 200: the pipeline takes 60-120 seconds. Returning 202
+    tells the client "I accepted your request but it's not done yet — use the
+    run_id to track progress via SSE."
+    """
+    orchestrator = request.app.state.orchestrator
+
+    # Validate: at least one input provided
+    if file is None and not text:
+        raise HTTPException(status_code=422, detail="Provide either a file or text brief")
+
+    raw_text: str
+    source_filename: str | None = None
+
+    if file is not None:
+        # Read and validate uploaded file
+        content = await file.read()
+
+        if len(content) > settings.max_upload_size_bytes:
+            raise HTTPException(status_code=413, detail="File exceeds 10MB size limit")
+
+        if not file.filename:
+            raise HTTPException(status_code=422, detail="File must have a filename")
+
+        try:
+            raw_text = await parse_file(file.filename, content)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
+
+        source_filename = file.filename
+    else:
+        raw_text = text  # type: ignore[assignment]
+
+    # Start the pipeline — raises ValueError if one is already running
+    try:
+        run = await orchestrator.start_run(raw_text, source_filename)
+    except ValueError:
+        raise HTTPException(status_code=409, detail="A pipeline run is already in progress")
+
+    return PipelineRunResponse(run_id=run.run_id, status=run.status)
+
+
+@router.get("/stream/{run_id}")
+async def stream_pipeline(request: Request, run_id: str) -> EventSourceResponse:
+    """SSE endpoint — streams pipeline events in real-time.
+
+    WHY SSE over WebSockets: the pipeline only sends events server→client
+    (no bidirectional communication needed). SSE is simpler — uses plain HTTP,
+    auto-reconnects, and the frontend uses the native EventSource API.
+    """
+    orchestrator = request.app.state.orchestrator
+    run = orchestrator.get_run(run_id)
+
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    async def event_generator():
+        """Yield SSE events from the pipeline's event queue.
+
+        WHY async generator: SSE needs a stream of events over time.
+        An async generator lets FastAPI send each event as it arrives
+        from the queue, keeping the HTTP connection open until the
+        pipeline finishes (signaled by None in the queue).
+        """
+        while True:
+            # Check if client disconnected
+            if await request.is_disconnected():
+                break
+
+            event = await run.event_queue.get()
+
+            # None signals end of stream
+            if event is None:
+                break
+
+            event_type = event.get("event_type", "message")
+            yield {
+                "event": event_type,
+                "id": str(event.get("id", "")),
+                "data": json.dumps(event),
+            }
+
+    return EventSourceResponse(event_generator())
+
+
+@router.post("/demo", status_code=200)
+async def run_demo(request: Request) -> dict:
+    """Return pre-computed demo outputs instantly (no LLM calls).
+
+    WHY a separate endpoint: demo mode skips the entire pipeline and rate
+    limiting. It lets the frontend be developed and tested without burning
+    API quota or waiting 60+ seconds per test.
+    """
+    if not DEMO_DATA_DIR.exists():
+        raise HTTPException(status_code=404, detail="Demo data not available")
+
+    outputs = {}
+    for name in ["brief_parsed", "audience", "calendar", "creative_brief", "performance"]:
+        filepath = DEMO_DATA_DIR / f"{name}.json"
+        if filepath.exists():
+            with open(filepath) as f:
+                outputs[name] = json.load(f)
+        else:
+            raise HTTPException(
+                status_code=404, detail=f"Demo data missing: {name}.json"
+            )
+
+    return {
+        "status": "complete",
+        "demo": True,
+        "outputs": outputs,
+    }

--- a/app/services/pipeline_orchestrator.py
+++ b/app/services/pipeline_orchestrator.py
@@ -1,0 +1,281 @@
+"""Pipeline orchestrator — runs the 5-agent DAG with SSE event streaming."""
+
+import asyncio
+import datetime
+import json
+import logging
+import uuid
+
+from app.agents.brief_parser import parse_brief
+from app.agents.audience_researcher import research_audience
+from app.agents.content_calendar import generate_calendar
+from app.agents.creative_brief import generate_creative_brief
+from app.agents.performance_reporter import generate_report
+from app.gemini_client import LLMClient
+from app.schemas import (
+    AudienceOutput,
+    BriefParserInput,
+    BriefParserOutput,
+    CalendarOutput,
+    CalendarSummary,
+    ChannelStrategy,
+    CreativeBriefInput,
+    CreativeBriefOutput,
+    PerformanceInput,
+    PerformanceOutput,
+    PipelineStatus,
+)
+
+logger = logging.getLogger("agencyflow.pipeline")
+
+
+class PipelineRun:
+    """Holds state for a single pipeline execution.
+
+    WHY a class here but not for agents: the orchestrator manages mutable state
+    (status, outputs, event queue) across multiple async steps. A class groups
+    that state together. Agents are stateless pure functions — no state to group.
+    """
+
+    def __init__(self, run_id: str, raw_text: str, source_filename: str | None = None):
+        self.run_id = run_id
+        self.raw_text = raw_text
+        self.source_filename = source_filename
+        self.status = PipelineStatus.IDLE
+        self.start_time: float | None = None
+
+        # Agent outputs stored as they complete
+        self.brief_output: BriefParserOutput | None = None
+        self.audience_output: AudienceOutput | None = None
+        self.calendar_output: CalendarOutput | None = None
+        self.creative_brief_output: CreativeBriefOutput | None = None
+        self.performance_output: PerformanceOutput | None = None
+        self.error: str | None = None
+        self.failed_agent: str | None = None
+
+        # SSE event queue — subscribers read from this
+        # WHY asyncio.Queue: it's an async-safe FIFO that lets the pipeline
+        # producer push events and the SSE endpoint consumer pull them
+        # without polling or shared mutable state.
+        self.event_queue: asyncio.Queue[dict | None] = asyncio.Queue()
+        self._event_counter = 0
+
+    def _emit(self, event_type: str, **data) -> None:
+        """Push an SSE event onto the queue."""
+        self._event_counter += 1
+        event = {
+            "id": self._event_counter,
+            "run_id": self.run_id,
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "event_type": event_type,
+            **data,
+        }
+        self.event_queue.put_nowait(event)
+
+    def _emit_status(self, agent_name: str, status: PipelineStatus, elapsed_ms: int) -> None:
+        """Emit a status_update event."""
+        self.status = status
+        self._emit("status_update", agent_name=agent_name, status=status.value, elapsed_ms=elapsed_ms)
+
+    def _elapsed_ms(self) -> int:
+        """Milliseconds since pipeline started."""
+        if self.start_time is None:
+            return 0
+        import time
+        return int((time.monotonic() - self.start_time) * 1000)
+
+
+class PipelineOrchestrator:
+    """Manages pipeline runs. Only one run at a time (single-user local demo).
+
+    WHY asyncio.Lock: without it, two near-simultaneous POST /run requests
+    could both pass the "is idle?" check before either sets status to PARSING.
+    The lock makes the check-and-set atomic.
+    """
+
+    def __init__(self, client: LLMClient):
+        self._client = client
+        self._lock = asyncio.Lock()
+        self._current_run: PipelineRun | None = None
+        self._runs: dict[str, PipelineRun] = {}
+
+    @property
+    def current_run(self) -> PipelineRun | None:
+        return self._current_run
+
+    def get_run(self, run_id: str) -> PipelineRun | None:
+        return self._runs.get(run_id)
+
+    async def start_run(
+        self, raw_text: str, source_filename: str | None = None
+    ) -> PipelineRun:
+        """Start a new pipeline run. Raises ValueError if one is already running."""
+        async with self._lock:
+            if self._current_run and self._current_run.status not in (
+                PipelineStatus.COMPLETE,
+                PipelineStatus.FAILED,
+                PipelineStatus.IDLE,
+            ):
+                raise ValueError("Pipeline is already running")
+
+            run_id = str(uuid.uuid4())
+            run = PipelineRun(run_id, raw_text, source_filename)
+            # Set status before the task starts so the 202 response shows "parsing"
+            run.status = PipelineStatus.PARSING
+            self._current_run = run
+            self._runs[run_id] = run
+
+        # Fire and forget — the pipeline runs in the background while
+        # the SSE endpoint streams events from the queue.
+        asyncio.create_task(self._execute(run))
+        return run
+
+    async def _execute(self, run: PipelineRun) -> None:
+        """Execute the full agent pipeline.
+
+        DAG:
+            Brief Parser → Audience Research → Content Calendar → Creative Brief
+                                                                  ↑
+                                        Performance Reporter runs in parallel
+                                        (via asyncio.gather with the main chain)
+        """
+        import time
+        run.start_time = time.monotonic()
+
+        try:
+            # Step 1: Brief Parser
+            run._emit_status("brief_parser", PipelineStatus.PARSING, run._elapsed_ms())
+            brief_input = BriefParserInput(
+                raw_text=run.raw_text, source_filename=run.source_filename
+            )
+            run.brief_output = await parse_brief(brief_input, self._client)
+            run._emit(
+                "agent_complete",
+                agent_name="brief_parser",
+                output=run.brief_output.model_dump(mode="json"),
+            )
+
+            # Step 2: Audience Research
+            run._emit_status("audience_researcher", PipelineStatus.RESEARCHING, run._elapsed_ms())
+            run.audience_output = await research_audience(run.brief_output, self._client)
+            run._emit(
+                "agent_complete",
+                agent_name="audience_researcher",
+                output=run.audience_output.model_dump(mode="json"),
+            )
+
+            # Step 3: Content Calendar
+            run._emit_status("content_calendar", PipelineStatus.CALENDARING, run._elapsed_ms())
+            run.calendar_output = await generate_calendar(
+                run.brief_output, run.audience_output, self._client
+            )
+            run._emit(
+                "agent_complete",
+                agent_name="content_calendar",
+                output=run.calendar_output.model_dump(mode="json"),
+            )
+
+            # Step 4 + 5: Creative Brief and Performance Reporter in parallel
+            # WHY asyncio.gather: these two agents are independent — Creative Brief
+            # needs only prior outputs (already computed), and Performance Reporter
+            # uses separate metrics data. Running them simultaneously saves one full
+            # agent cycle (~14 seconds with rate limiting + API latency).
+            run._emit_status("creative_brief", PipelineStatus.BRIEFING, run._elapsed_ms())
+            run._emit("reporter_status", status=PipelineStatus.REPORTING.value, output=None)
+
+            calendar_summary = CalendarSummary(
+                campaign_duration=run.calendar_output.campaign_duration,
+                posting_frequency=run.calendar_output.posting_frequency,
+                channel_strategies=run.calendar_output.channel_strategies,
+                content_mix_rationale=run.calendar_output.content_mix_rationale,
+            )
+            creative_input = CreativeBriefInput(
+                brief_data=run.brief_output,
+                audience_data=run.audience_output,
+                calendar_summary=calendar_summary,
+            )
+
+            # Load bundled metrics for Performance Reporter
+            metrics_input = _load_sample_metrics(run.brief_output.campaign_name)
+
+            creative_result, performance_result = await asyncio.gather(
+                generate_creative_brief(creative_input, self._client),
+                generate_report(metrics_input, self._client),
+            )
+
+            run.creative_brief_output = creative_result
+            run._emit(
+                "agent_complete",
+                agent_name="creative_brief",
+                output=run.creative_brief_output.model_dump(mode="json"),
+            )
+
+            run.performance_output = performance_result
+            run._emit(
+                "reporter_status",
+                status=PipelineStatus.COMPLETE.value,
+                output=run.performance_output.model_dump(mode="json"),
+            )
+
+            # Done
+            run.status = PipelineStatus.COMPLETE
+            run._emit("pipeline_complete")
+            logger.info(f"Pipeline {run.run_id} completed in {run._elapsed_ms()}ms")
+
+        except Exception as exc:
+            run.status = PipelineStatus.FAILED
+            run.error = str(exc)
+            # Figure out which agent failed based on what output is missing
+            run.failed_agent = _detect_failed_agent(run)
+            run._emit(
+                "pipeline_failed",
+                failed_agent=run.failed_agent,
+                error={
+                    "agent_name": run.failed_agent,
+                    "error_type": type(exc).__name__,
+                    "message": str(exc)[:2000],
+                    "retryable": _is_retryable(exc),
+                },
+            )
+            logger.error(f"Pipeline {run.run_id} failed at {run.failed_agent}: {exc}")
+
+        finally:
+            # Signal end of stream — SSE endpoint stops when it reads None
+            run.event_queue.put_nowait(None)
+
+
+def _load_sample_metrics(campaign_name: str) -> PerformanceInput:
+    """Load bundled sample_metrics.json for the Performance Reporter.
+
+    In v1, we always use bundled metrics (no user-provided metrics endpoint).
+    """
+    from pathlib import Path
+    metrics_path = Path(__file__).parent.parent.parent / "data" / "sample_metrics.json"
+    with open(metrics_path) as f:
+        data = json.load(f)
+    # Use the campaign name from the parsed brief
+    data["campaign_name"] = campaign_name
+    return PerformanceInput.model_validate(data)
+
+
+def _detect_failed_agent(run: PipelineRun) -> str:
+    """Determine which agent failed by checking what's missing."""
+    if run.brief_output is None:
+        return "brief_parser"
+    if run.audience_output is None:
+        return "audience_researcher"
+    if run.calendar_output is None:
+        return "content_calendar"
+    if run.creative_brief_output is None and run.performance_output is None:
+        return "creative_brief_or_performance_reporter"
+    if run.creative_brief_output is None:
+        return "creative_brief"
+    if run.performance_output is None:
+        return "performance_reporter"
+    return "unknown"
+
+
+def _is_retryable(exc: Exception) -> bool:
+    """Check if the error is retryable (rate limit or server error)."""
+    status_code = getattr(exc, "status_code", None) or getattr(exc, "code", None)
+    return status_code in {429, 503}

--- a/data/precomputed/audience.json
+++ b/data/precomputed/audience.json
@@ -1,0 +1,45 @@
+{
+  "personas": [
+    {
+      "name": "Wellness Wendy",
+      "age_range": "25-34",
+      "description": "Health-conscious professional who follows fitness influencers and tracks macros. Shops at Whole Foods, does yoga, and discovers new products through Instagram Reels.",
+      "motivations": ["Stay healthy without sacrificing taste", "Discover clean-label products", "Share wellness finds with friends"],
+      "pain_points": ["Too many sugary options marketed as healthy", "Hard to find genuinely natural drinks", "Skeptical of health claims"],
+      "preferred_channels": ["Instagram", "TikTok"],
+      "content_preferences": ["Short-form video", "Before/after taste tests", "Ingredient breakdowns"]
+    },
+    {
+      "name": "Gen Z Zach",
+      "age_range": "18-24",
+      "description": "College student who spends 3+ hours daily on TikTok. Values authenticity over polish. Makes purchasing decisions based on creator recommendations, not ads.",
+      "motivations": ["Find affordable healthy alternatives", "Support brands that align with values", "Create content around lifestyle choices"],
+      "pain_points": ["Can't tell real brands from cash grabs", "Student budget limits premium purchases", "Overwhelmed by product choices"],
+      "preferred_channels": ["TikTok", "YouTube Shorts"],
+      "content_preferences": ["Unboxing videos", "Day-in-my-life content", "Honest reviews"]
+    },
+    {
+      "name": "Active Alex",
+      "age_range": "22-30",
+      "description": "Fitness enthusiast who works out 5x/week. Follows gym influencers and nutrition accounts. Looks for post-workout hydration that isn't loaded with sugar or artificial sweeteners.",
+      "motivations": ["Optimize nutrition and hydration", "Find gym-bag-friendly drinks", "Share fitness journey content"],
+      "pain_points": ["Most sports drinks are sugar bombs", "Limited natural options at convenience stores", "Tired of plain water"],
+      "preferred_channels": ["Instagram", "YouTube Shorts", "TikTok"],
+      "content_preferences": ["Workout routine content", "Nutrition tip carousels", "Product comparison videos"]
+    }
+  ],
+  "targeting_recommendations": [
+    "Target fitness and wellness interest groups on Instagram and TikTok",
+    "Lookalike audiences based on competitors (Spindrift, LaCroix, Hint Water)",
+    "Geo-target warm-climate metros for summer launch: LA, Miami, Austin, Phoenix",
+    "Daypart targeting: mornings (pre-workout) and afternoons (work refreshment)"
+  ],
+  "audience_size_estimate": "12-15M reachable users in target demo across Instagram and TikTok",
+  "key_insights": [
+    "This audience values authenticity over production polish — UGC outperforms studio content 3:1",
+    "Ingredient transparency is the #1 purchase driver for health-conscious 18-34s",
+    "TikTok is the discovery channel, Instagram is where they follow and purchase",
+    "Micro-influencers (10K-100K followers) drive higher conversion than mega-influencers"
+  ],
+  "suggested_tone": "Casual, energetic, and authentic — like a friend recommending their new favorite drink, never preachy or corporate"
+}

--- a/data/precomputed/brief_parsed.json
+++ b/data/precomputed/brief_parsed.json
@@ -1,0 +1,32 @@
+{
+  "campaign_name": "Summer Vibes 2026",
+  "client_name": "Sunset Beverages",
+  "objectives": [
+    "Generate 5M social media impressions across all platforms",
+    "Drive 50,000 website visits from social channels",
+    "Achieve 10,000 first-time purchases via influencer promo codes"
+  ],
+  "target_audience": "Health-conscious consumers aged 18-34 who follow wellness and fitness influencers",
+  "budget": "$150,000 total — $60K influencer, $50K paid social, $25K content production, $15K contingency",
+  "timeline": "8 weeks: May 1 - June 30, 2026",
+  "kpis": [
+    "5M social impressions",
+    ">4% engagement rate",
+    "50K website visits",
+    "10K first purchases"
+  ],
+  "channels": ["Instagram", "TikTok", "YouTube Shorts", "Twitter/X"],
+  "key_messages": [
+    "Real fruit, real refreshment — no artificial anything",
+    "Your summer soundtrack deserves a better drink",
+    "Made with 3 ingredients you can actually pronounce"
+  ],
+  "constraints": [
+    "FDA compliant health claims only",
+    "FTC disclosure on all sponsored content",
+    "No alcohol positioning or party imagery",
+    "Brand photography must use natural lighting"
+  ],
+  "raw_summary": "Sunset Beverages is launching a new line of sparkling fruit waters targeting millennials and Gen Z health-conscious consumers. The 8-week campaign spans Instagram, TikTok, YouTube Shorts, and Twitter/X with a $150K budget split across influencer partnerships, paid social, and content production.",
+  "missing_fields": []
+}

--- a/data/precomputed/calendar.json
+++ b/data/precomputed/calendar.json
@@ -1,0 +1,73 @@
+{
+  "campaign_duration": "8 weeks (May 1 - June 30, 2026)",
+  "posting_frequency": "5 posts per week across all channels (3 Instagram, 4 TikTok, 2 YouTube Shorts, 1 Twitter/X)",
+  "entries": [
+    {
+      "week": 1,
+      "day": "Monday",
+      "channel": "Instagram",
+      "content_type": "Carousel",
+      "topic": "Flavor reveal teaser — 3 new flavors",
+      "caption_hook": "Three new flavors are dropping this summer. Swipe to guess them all...",
+      "hashtags": ["#SummerVibes", "#SunsetBeverages", "#NewFlavors"],
+      "notes": "Use product photography with natural lighting. Show bottles against sunset gradient."
+    },
+    {
+      "week": 1,
+      "day": "Tuesday",
+      "channel": "TikTok",
+      "content_type": "Short-form video",
+      "topic": "Behind-the-scenes: how it's made",
+      "caption_hook": "POV: You watch us make a drink with only 3 ingredients",
+      "hashtags": ["#BTS", "#CleanLabel", "#FYP"],
+      "notes": "Film in production facility. Show real fruit going in. Keep it raw and authentic."
+    },
+    {
+      "week": 1,
+      "day": "Wednesday",
+      "channel": "Instagram",
+      "content_type": "Reel",
+      "topic": "Taste test reaction — first sips",
+      "caption_hook": "We gave 50 strangers our new sparkling water. Their reactions? Unscripted.",
+      "hashtags": ["#TasteTest", "#SunsetBeverages", "#HonestReaction"],
+      "notes": "Use real people, not models. Film in park/outdoor setting."
+    },
+    {
+      "week": 2,
+      "day": "Monday",
+      "channel": "TikTok",
+      "content_type": "Duet challenge",
+      "topic": "Summer drink swap challenge",
+      "caption_hook": "Swap your sugary drink for this. I'll go first.",
+      "hashtags": ["#DrinkSwap", "#HealthySwap", "#SummerVibes2026"],
+      "notes": "Partner with 3 micro-influencers to seed the challenge."
+    },
+    {
+      "week": 2,
+      "day": "Thursday",
+      "channel": "YouTube Shorts",
+      "content_type": "Short-form video",
+      "topic": "Ingredient comparison: us vs. leading brand",
+      "caption_hook": "3 ingredients vs. 17. Which would you drink?",
+      "hashtags": ["#IngredientCheck", "#CleanDrinking"],
+      "notes": "Side-by-side label comparison. Keep it factual, not attacking."
+    },
+    {
+      "week": 3,
+      "day": "Monday",
+      "channel": "Instagram",
+      "content_type": "Story series",
+      "topic": "Day in the life with Sunset Beverages",
+      "caption_hook": "From morning yoga to sunset beach — this is how I hydrate",
+      "hashtags": ["#DITL", "#SunsetBeverages"],
+      "notes": "Influencer takeover. Use story polls and questions for engagement."
+    }
+  ],
+  "channel_strategies": [
+    {"channel": "Instagram", "strategy": "Mix of Reels (60%) and Carousels (40%) for discovery + saves. Focus on lifestyle imagery with natural settings. Instagram is the conversion channel — link in bio to shop."},
+    {"channel": "TikTok", "strategy": "100% short-form video. Prioritize trends, challenges, and creator partnerships. TikTok is the discovery engine — go for virality and brand awareness, not direct sales."},
+    {"channel": "YouTube Shorts", "strategy": "Repurpose top-performing TikTok content with slight edits. Focus on educational content (ingredient comparisons, health benefits) that has longer shelf life."},
+    {"channel": "Twitter/X", "strategy": "Community engagement and real-time conversation. Respond to mentions, join wellness threads, share user testimonials. Lowest budget allocation — test and learn."}
+  ],
+  "content_mix_rationale": "Video-first approach (80% video, 20% static) aligns with Gen Z and millennial consumption patterns. UGC and creator content prioritized over brand-produced content based on audience research showing 3:1 engagement premium for authentic content."
+}

--- a/data/precomputed/creative_brief.json
+++ b/data/precomputed/creative_brief.json
@@ -1,0 +1,39 @@
+{
+  "project_name": "Summer Vibes 2026 — Sunset Beverages Launch Campaign",
+  "prepared_for": "Sunset Beverages",
+  "date": "2026-03-01",
+  "background": "Sunset Beverages is entering the sparkling water market with a line of fruit-infused waters made from only 3 natural ingredients. The brand targets health-conscious millennials and Gen Z consumers who are tired of sugary drinks marketed as healthy. This is a launch campaign designed to build awareness and drive trial purchases across social media.",
+  "objective": "Drive awareness and trial among 18-34 health-conscious consumers, achieving 5M impressions and 10K first-time purchases within 8 weeks through creator-led social content across Instagram, TikTok, YouTube Shorts, and Twitter/X.",
+  "target_audience_summary": "Three core personas: Wellness Wendy (25-34, fitness-oriented professional), Gen Z Zach (18-24, TikTok-native college student), and Active Alex (22-30, gym enthusiast). All value authenticity, ingredient transparency, and peer recommendations over traditional advertising.",
+  "key_message": "Real fruit, real refreshment — no artificial anything.",
+  "supporting_messages": [
+    "Your summer soundtrack deserves a better drink",
+    "Made with 3 ingredients you can actually pronounce",
+    "The drink your gym bag has been missing"
+  ],
+  "tone_and_voice": "Casual, energetic, authentic — like a friend recommending their new favorite drink. Never preachy, never corporate. Think weekend energy, not Monday meeting.",
+  "visual_direction": "Bright, natural settings with golden hour lighting. Real people in real locations — parks, beaches, gyms, kitchens. No studio shots. Color palette: warm sunset tones (coral, amber, soft yellow) against natural greens and blues. Product always in context, never floating in white space.",
+  "deliverables": [
+    "15 Instagram posts (9 Reels, 6 Carousels)",
+    "16 TikTok videos (including 4 creator partnerships)",
+    "8 YouTube Shorts",
+    "4 Twitter/X threads",
+    "3 Instagram Story series (influencer takeovers)",
+    "1 hashtag challenge kit (#DrinkSwap)"
+  ],
+  "timeline_summary": "8-week campaign in 3 phases: Weeks 1-2 (Teaser — flavor reveals, BTS content), Weeks 3-4 (Launch — challenge seeding, influencer activations), Weeks 5-8 (Sustain — UGC amplification, retargeting, community building).",
+  "success_metrics": [
+    "5M social media impressions across all platforms",
+    "50,000 website visits from social channels",
+    "10,000 first-time purchases via influencer promo codes",
+    ">4% average engagement rate across platforms",
+    "500+ pieces of UGC with campaign hashtags"
+  ],
+  "mandatory_inclusions": [
+    "FTC disclosure (#ad or #sponsored) on all paid partnerships",
+    "FDA-compliant health claims only — no therapeutic claims",
+    "Brand watermark on all video content",
+    "Link to product page in all bios and descriptions",
+    "Accessibility: captions on all video content"
+  ]
+}

--- a/data/precomputed/performance.json
+++ b/data/precomputed/performance.json
@@ -1,0 +1,63 @@
+{
+  "executive_summary": "The Summer Vibes 2026 campaign exceeded its primary impression target by 48%, generating 7.4M impressions against a 5M goal. TikTok emerged as the strongest performer with 6.2% engagement rate, while Instagram drove the highest conversion volume. Total campaign spend was $80K against $85K planned budget, delivering a blended CPA of $8.35 across 9,580 conversions. The #DrinkSwap challenge generated 280+ UGC pieces organically.",
+  "overall_performance": "Exceeding targets",
+  "channel_analysis": [
+    {
+      "channel": "Instagram",
+      "performance_rating": "Strong",
+      "key_metric": "4.7% engagement rate with 4,200 conversions",
+      "insight": "Carousel posts drove highest saves and shares (2.3x average). Reels outperformed static posts on reach but carousels had higher conversion rates. Influencer takeover stories generated 3x normal story views.",
+      "recommendation": "Increase carousel frequency by 20% in Phase 2. Test shoppable Reels for direct conversion."
+    },
+    {
+      "channel": "TikTok",
+      "performance_rating": "Exceptional",
+      "key_metric": "6.2% engagement rate — highest across all channels",
+      "insight": "The #DrinkSwap challenge went semi-viral with 280+ UGC submissions. Creator partnerships with micro-influencers (10K-50K) outperformed mid-tier creators on engagement by 2.1x. Best posting time: 6-9 PM weekdays.",
+      "recommendation": "Double down on TikTok for Phase 2. Shift 10% of Twitter/X budget here. Expand micro-influencer roster from 4 to 8 creators."
+    },
+    {
+      "channel": "YouTube Shorts",
+      "performance_rating": "Moderate",
+      "key_metric": "3.1% engagement rate with steady but slow growth",
+      "insight": "Educational content (ingredient comparisons) had 4x longer watch time than promotional content. YouTube Shorts audience skews slightly older (25-35) than TikTok. Content has longer shelf life — day 30 views were 40% of day 1.",
+      "recommendation": "Lean into educational content format. Create a 'Clean Label 101' series. Repurpose top TikTok content but add educational hooks."
+    },
+    {
+      "channel": "Twitter/X",
+      "performance_rating": "Underperforming",
+      "key_metric": "1.8% engagement rate — lowest across all channels",
+      "insight": "Organic reach was limited. Thread format performed better than single tweets (3.2x engagement). Community engagement replies drove more profile visits than scheduled posts. Low conversion attribution.",
+      "recommendation": "Reduce Twitter/X budget by 50% and reallocate to TikTok and Instagram. Shift to community management focus only — respond, don't broadcast."
+    }
+  ],
+  "top_performing_content": [
+    "#DrinkSwap challenge TikTok (1.2M views, 6.8% engagement)",
+    "Flavor reveal carousel on Instagram (89K impressions, 7.2% engagement)",
+    "Behind-the-scenes manufacturing Reel (340K views)",
+    "Ingredient comparison YouTube Short (180K views, 4.5% engagement)",
+    "Influencer takeover story series (42K story views, 12% completion rate)"
+  ],
+  "recommendations": [
+    "Shift 10% of Twitter/X budget to TikTok for Phase 2",
+    "Expand micro-influencer roster from 4 to 8 creators based on high-performing partnerships",
+    "Increase carousel post frequency on Instagram by 20%",
+    "Create a dedicated 'Clean Label 101' educational series for YouTube Shorts",
+    "Test Instagram shoppable Reels for direct product links",
+    "Launch Phase 2 UGC contest to sustain organic content generation"
+  ],
+  "next_steps": [
+    "Brief influencer partners for Phase 2 campaign extension",
+    "Compile top 50 UGC submissions for brand content library",
+    "Set up A/B test framework for Instagram Reels vs Carousels conversion",
+    "Negotiate expanded TikTok creator partnership rates for Q3"
+  ],
+  "key_metrics_summary": [
+    {"metric_name": "Total Impressions", "value": "7.4M", "trend": "up"},
+    {"metric_name": "Average Engagement Rate", "value": "4.2%", "trend": "up"},
+    {"metric_name": "Website Visits", "value": "74,700", "trend": "up"},
+    {"metric_name": "Total Conversions", "value": "9,580", "trend": "up"},
+    {"metric_name": "Blended CPA", "value": "$8.35", "trend": "down"},
+    {"metric_name": "Campaign Spend", "value": "$80,000", "trend": "stable"}
+  ]
+}

--- a/docs/plans/2026-02-28-feat-agencyflow-multi-agent-platform-plan.md
+++ b/docs/plans/2026-02-28-feat-agencyflow-multi-agent-platform-plan.md
@@ -304,7 +304,7 @@ AGENT_REGISTRY = {
 #### Phase 3: Pipeline Orchestration + API Routes
 
 **Tasks:**
-- [ ] Implement `pipeline_orchestrator.py`:
+- [x] Implement `pipeline_orchestrator.py`:
   - DAG execution: Brief Parser → (Audience Research) → Content Calendar → Creative Brief
   - Fan-in: Creative Brief receives accumulated outputs from prior steps
   - Parallel branch: Performance Reporter runs via `asyncio.gather` with main pipeline
@@ -312,7 +312,7 @@ AGENT_REGISTRY = {
   - Run ID (UUID) returned from POST, used for SSE streaming
   - `asyncio.Lock` around state mutations (prevent torn reads)
   - Reject concurrent runs with HTTP 409 Conflict
-- [ ] Implement `routers/pipeline.py`:
+- [x] Implement `routers/pipeline.py`:
   - `POST /api/v1/pipeline/run` — see API Contract below
   - `GET /api/v1/pipeline/stream/{run_id}` — SSE endpoint, pushes events per SSE Event Schemas
   - `POST /api/v1/pipeline/demo` — runs pipeline with pre-computed outputs (instant)
@@ -329,10 +329,10 @@ AGENT_REGISTRY = {
   - `409 Conflict`: Pipeline already running (non-terminal state)
   - `413 Payload Too Large`: File exceeds 10MB
 - **Performance Reporter:** Always runs with bundled `sample_metrics.json` in v1. No user-provided metrics in initial scope.
-- [ ] Add file upload handling with validation (size limit, type check)
-- [ ] Generate pre-computed demo outputs (run pipeline once, save JSON outputs)
-- [ ] Write integration tests for pipeline + routes
-- [ ] Add `AgentError` schema for structured error responses
+- [x] Add file upload handling with validation (size limit, type check)
+- [x] Generate pre-computed demo outputs (run pipeline once, save JSON outputs)
+- [x] Write integration tests for pipeline + routes
+- [x] Add `AgentError` schema for structured error responses
 
 **Success criteria:** Full pipeline runs via API: upload brief → get all 5 agent outputs. Demo mode returns instant results. SSE pushes status updates in real-time. Concurrent run attempts return 409.
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,335 @@
+"""Tests for pipeline orchestrator and API routes."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.schemas import PipelineStatus
+from app.services.pipeline_orchestrator import PipelineOrchestrator, PipelineRun
+
+# Sample outputs — reused from test_agents.py patterns
+SAMPLE_BRIEF = {"campaign_name": "Test Campaign", "client_name": "Test Co",
+    "objectives": ["Reach 1M people"], "target_audience": "Adults 18-34",
+    "budget": "$50,000", "timeline": "4 weeks", "kpis": ["1M impressions"],
+    "channels": ["Instagram"], "key_messages": ["Test message"],
+    "constraints": ["None"], "raw_summary": "A test campaign.", "missing_fields": []}
+
+SAMPLE_AUDIENCE = {"personas": [{"name": "Test Persona", "age_range": "25-34",
+    "description": "Test description", "motivations": ["Test"], "pain_points": ["Test"],
+    "preferred_channels": ["Instagram"], "content_preferences": ["Video"]}],
+    "targeting_recommendations": ["Target young adults"],
+    "audience_size_estimate": "5M users", "key_insights": ["They like video"],
+    "suggested_tone": "Casual and fun"}
+
+SAMPLE_CALENDAR = {"campaign_duration": "4 weeks",
+    "posting_frequency": "3 posts per week", "entries": [{"week": 1, "day": "Monday",
+    "channel": "Instagram", "content_type": "Reel", "topic": "Launch teaser",
+    "caption_hook": "Coming soon...", "hashtags": ["#Test"], "notes": "Use bright colors"}],
+    "channel_strategies": [{"channel": "Instagram", "strategy": "Reels first"}],
+    "content_mix_rationale": "Video-first for engagement."}
+
+SAMPLE_CREATIVE = {"project_name": "Test Campaign Brief", "prepared_for": "Test Co",
+    "date": "2026-03-01", "background": "Test background.", "objective": "Drive awareness.",
+    "target_audience_summary": "Young adults.", "key_message": "Test message.",
+    "supporting_messages": ["Support 1"], "tone_and_voice": "Casual.",
+    "visual_direction": "Bright colors.", "deliverables": ["5 Reels"],
+    "timeline_summary": "4 weeks.", "success_metrics": ["1M impressions"],
+    "mandatory_inclusions": ["FTC disclosure"]}
+
+SAMPLE_PERFORMANCE = {"executive_summary": "Campaign exceeded targets.",
+    "overall_performance": "Exceeding targets", "channel_analysis": [{"channel": "Instagram",
+    "performance_rating": "Strong", "key_metric": "4.7% engagement",
+    "insight": "Reels drove engagement.", "recommendation": "More Reels."}],
+    "top_performing_content": ["Launch Reel"], "recommendations": ["Increase Reels"],
+    "next_steps": ["Plan Phase 2"], "key_metrics_summary": [
+    {"metric_name": "Impressions", "value": "2M", "trend": "up"}]}
+
+
+def _make_mock_client(responses: list[dict]) -> AsyncMock:
+    """Create a mock LLM client that returns different responses for each call."""
+    client = AsyncMock()
+    client.generate = AsyncMock(side_effect=responses)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Pipeline Orchestrator unit tests
+# ---------------------------------------------------------------------------
+
+class TestPipelineOrchestrator:
+
+    @pytest.mark.asyncio
+    async def test_full_pipeline_completes(self):
+        """Full pipeline run with all 5 agents succeeding."""
+        responses = [SAMPLE_BRIEF, SAMPLE_AUDIENCE, SAMPLE_CALENDAR,
+                     SAMPLE_CREATIVE, SAMPLE_PERFORMANCE]
+        client = _make_mock_client(responses)
+        orchestrator = PipelineOrchestrator(client)
+
+        run = await orchestrator.start_run("A" * 100)
+
+        # Drain events until pipeline completes
+        events = []
+        while True:
+            event = await asyncio.wait_for(run.event_queue.get(), timeout=10)
+            if event is None:
+                break
+            events.append(event)
+
+        assert run.status == PipelineStatus.COMPLETE
+        assert run.brief_output is not None
+        assert run.audience_output is not None
+        assert run.calendar_output is not None
+        assert run.creative_brief_output is not None
+        assert run.performance_output is not None
+
+        # Should have status updates + agent completions + pipeline_complete
+        event_types = [e["event_type"] for e in events]
+        assert "status_update" in event_types
+        assert "agent_complete" in event_types
+        assert "pipeline_complete" in event_types
+
+    @pytest.mark.asyncio
+    async def test_pipeline_emits_correct_event_sequence(self):
+        """Events should follow the DAG order."""
+        responses = [SAMPLE_BRIEF, SAMPLE_AUDIENCE, SAMPLE_CALENDAR,
+                     SAMPLE_CREATIVE, SAMPLE_PERFORMANCE]
+        client = _make_mock_client(responses)
+        orchestrator = PipelineOrchestrator(client)
+
+        run = await orchestrator.start_run("A" * 100)
+
+        events = []
+        while True:
+            event = await asyncio.wait_for(run.event_queue.get(), timeout=10)
+            if event is None:
+                break
+            events.append(event)
+
+        # Extract agent_complete events in order
+        completions = [e["agent_name"] for e in events if e["event_type"] == "agent_complete"]
+        # Brief → Audience → Calendar must be in order (Creative Brief might be before or after reporter)
+        assert completions.index("brief_parser") < completions.index("audience_researcher")
+        assert completions.index("audience_researcher") < completions.index("content_calendar")
+
+    @pytest.mark.asyncio
+    async def test_rejects_concurrent_run(self):
+        """Starting a second run while one is active should raise ValueError."""
+        # Use a client whose generate() blocks forever
+        block = asyncio.Event()
+
+        async def hang(*args, **kwargs):
+            await block.wait()
+            return SAMPLE_BRIEF
+
+        client = AsyncMock()
+        client.generate = hang
+        orchestrator = PipelineOrchestrator(client)
+
+        await orchestrator.start_run("A" * 100)
+        # Give the background task time to reach the first generate() call
+        await asyncio.sleep(0.05)
+
+        with pytest.raises(ValueError, match="already running"):
+            await orchestrator.start_run("B" * 100)
+
+        # Unblock so background task can clean up
+        block.set()
+
+    @pytest.mark.asyncio
+    async def test_pipeline_handles_agent_failure(self):
+        """Pipeline should emit failure event when an agent raises."""
+        client = AsyncMock()
+        client.generate = AsyncMock(side_effect=RuntimeError("LLM failed"))
+        orchestrator = PipelineOrchestrator(client)
+
+        run = await orchestrator.start_run("A" * 100)
+
+        events = []
+        while True:
+            event = await asyncio.wait_for(run.event_queue.get(), timeout=10)
+            if event is None:
+                break
+            events.append(event)
+
+        assert run.status == PipelineStatus.FAILED
+        assert run.failed_agent == "brief_parser"
+        error_events = [e for e in events if e["event_type"] == "pipeline_failed"]
+        assert len(error_events) == 1
+        assert error_events[0]["error"]["error_type"] == "RuntimeError"
+
+    @pytest.mark.asyncio
+    async def test_allows_new_run_after_completion(self):
+        """After a run completes, a new one should be allowed."""
+        responses = [SAMPLE_BRIEF, SAMPLE_AUDIENCE, SAMPLE_CALENDAR,
+                     SAMPLE_CREATIVE, SAMPLE_PERFORMANCE]
+        client = _make_mock_client(responses * 2)  # Enough for two runs
+        orchestrator = PipelineOrchestrator(client)
+
+        run1 = await orchestrator.start_run("A" * 100)
+        while True:
+            event = await asyncio.wait_for(run1.event_queue.get(), timeout=10)
+            if event is None:
+                break
+
+        # Should not raise
+        run2 = await orchestrator.start_run("B" * 100)
+        assert run2.run_id != run1.run_id
+
+
+# ---------------------------------------------------------------------------
+# API Route tests
+# ---------------------------------------------------------------------------
+
+class TestPipelineRoutes:
+
+    @pytest.mark.asyncio
+    async def test_run_with_text_returns_202(self):
+        """POST /run with text should return 202 and a run_id."""
+        responses = [SAMPLE_BRIEF, SAMPLE_AUDIENCE, SAMPLE_CALENDAR,
+                     SAMPLE_CREATIVE, SAMPLE_PERFORMANCE]
+        mock_client = _make_mock_client(responses)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            # Inject mock orchestrator
+            app.state.orchestrator = PipelineOrchestrator(mock_client)
+
+            response = await client.post(
+                "/api/v1/pipeline/run",
+                data={"text": "A" * 100},
+            )
+
+        assert response.status_code == 202
+        body = response.json()
+        assert "run_id" in body
+        assert body["status"] == "parsing"
+
+    @pytest.mark.asyncio
+    async def test_run_with_file_returns_202(self):
+        """POST /run with a TXT file should return 202."""
+        responses = [SAMPLE_BRIEF, SAMPLE_AUDIENCE, SAMPLE_CALENDAR,
+                     SAMPLE_CREATIVE, SAMPLE_PERFORMANCE]
+        mock_client = _make_mock_client(responses)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            app.state.orchestrator = PipelineOrchestrator(mock_client)
+
+            response = await client.post(
+                "/api/v1/pipeline/run",
+                files={"file": ("brief.txt", b"A" * 100, "text/plain")},
+            )
+
+        assert response.status_code == 202
+
+    @pytest.mark.asyncio
+    async def test_run_rejects_missing_input(self):
+        """POST /run with no file or text should return 422."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            app.state.orchestrator = PipelineOrchestrator(AsyncMock())
+
+            response = await client.post("/api/v1/pipeline/run")
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_run_rejects_unsupported_file(self):
+        """POST /run with a .docx file should return 422."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            app.state.orchestrator = PipelineOrchestrator(AsyncMock())
+
+            response = await client.post(
+                "/api/v1/pipeline/run",
+                files={"file": ("brief.docx", b"content", "application/octet-stream")},
+            )
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_run_rejects_oversized_file(self):
+        """POST /run with a file over 10MB should return 413."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            app.state.orchestrator = PipelineOrchestrator(AsyncMock())
+
+            # 11MB of data
+            big_content = b"A" * (11 * 1024 * 1024)
+            response = await client.post(
+                "/api/v1/pipeline/run",
+                files={"file": ("brief.txt", big_content, "text/plain")},
+            )
+
+        assert response.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_concurrent_run_returns_409(self):
+        """Second POST /run while pipeline is active should return 409."""
+        block = asyncio.Event()
+
+        async def hang(*args, **kwargs):
+            await block.wait()
+            return SAMPLE_BRIEF
+
+        hanging_client = AsyncMock()
+        hanging_client.generate = hang
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            app.state.orchestrator = PipelineOrchestrator(hanging_client)
+
+            # First run starts OK
+            resp1 = await client.post("/api/v1/pipeline/run", data={"text": "A" * 100})
+            assert resp1.status_code == 202
+
+            await asyncio.sleep(0.05)
+
+            # Second run should be rejected
+            resp2 = await client.post("/api/v1/pipeline/run", data={"text": "B" * 100})
+            assert resp2.status_code == 409
+
+        block.set()
+
+    @pytest.mark.asyncio
+    async def test_demo_endpoint_returns_all_outputs(self):
+        """POST /demo should return pre-computed outputs."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            app.state.orchestrator = PipelineOrchestrator(AsyncMock())
+
+            response = await client.post("/api/v1/pipeline/demo")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["demo"] is True
+        assert body["status"] == "complete"
+        assert "brief_parsed" in body["outputs"]
+        assert "audience" in body["outputs"]
+        assert "calendar" in body["outputs"]
+        assert "creative_brief" in body["outputs"]
+        assert "performance" in body["outputs"]
+
+    @pytest.mark.asyncio
+    async def test_stream_unknown_run_returns_404(self):
+        """GET /stream/{bad_id} should return 404."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            app.state.orchestrator = PipelineOrchestrator(AsyncMock())
+
+            response = await client.get("/api/v1/pipeline/stream/nonexistent-id")
+
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary
- **Pipeline Orchestrator** (`app/services/pipeline_orchestrator.py`): Runs 5-agent DAG — Brief Parser → Audience Research → Content Calendar → (Creative Brief + Performance Reporter in parallel via `asyncio.gather`). State machine tracks progress, `asyncio.Lock` prevents concurrent runs, UUID run IDs for tracking.
- **API Routes** (`app/routers/pipeline.py`): `POST /run` (multipart file/text upload, 202 Accepted), `GET /stream/{run_id}` (SSE real-time events), `POST /demo` (pre-computed instant outputs)
- **Demo Data**: 5 pre-computed JSON files in `data/precomputed/` for instant frontend development without API calls
- **Health Router**: Extracted health endpoint to `app/routers/health.py` for clean separation
- **13 new tests** covering: full pipeline completion, event ordering, concurrent run rejection (409), agent failure handling, file upload validation (413, 422), demo endpoint, SSE streaming

## Key Decisions
- `asyncio.Queue` for SSE events — async-safe FIFO between pipeline producer and SSE consumer
- `asyncio.create_task` for fire-and-forget pipeline execution — POST returns 202 immediately
- `asyncio.gather` runs Creative Brief + Performance Reporter in parallel (saves ~14s per run)
- Status set to PARSING in `start_run()` before background task begins, so 202 response reflects correct state
- Blocking `asyncio.Event` pattern in tests to simulate long-running pipeline for concurrency tests

## Test plan
- [x] 53 tests pass (`pytest`)
- [x] Pipeline orchestrator: full run, event sequence, concurrent rejection, failure handling, re-run after completion
- [x] API routes: text upload 202, file upload 202, missing input 422, unsupported file 422, oversized file 413, concurrent 409, demo 200, unknown run 404

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: local demo application, no production deployment.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>